### PR TITLE
Hide user-info when server crashes

### DIFF
--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -1,4 +1,4 @@
-import { loginButton, mainCardsArea } from "./domUpdates";
+import { hotelCheckInInfo, loginButton, mainCardsArea } from "./domUpdates";
 let baseUrl = 'http://localhost:3001/api/v1/'
 
 /////////NIK's re-implimented code/////////////////////////////////
@@ -9,6 +9,7 @@ const displayErrorMesssage = (err) => {
       ? "Our network temporarily is down due to cyber attacks. Please call us or email us @ thegrandbudapest@gmail.com"
       : err.message;
   errorField.innerHTML = message;
+  hotelCheckInInfo.classList.add('hide')
 };
 const disableLoginButton = () => {
   loginButton.setAttribute('disabled', 'true');


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring
# How Has This Been Tested?
- [x] open localHost
- [ ] test through Mocha/Chai
- [ ] dev tools
# Checklist:
- [ ] My code follows the Turing's guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] No console error messages


So I removed the user-info area if the server crashes or is not up when the user tries to log in or when they try to book a room when the server is down